### PR TITLE
Optionify createColros parameter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -54,7 +54,7 @@ export const isColorSupported: boolean
  * @param enabled Do we need to enable colors. On `undefined` we will try
  *                to detect color support.
  */
-export function createColors(enabled: boolean | undefined): Colors
+export function createColors(enabled?: boolean): Colors
 
 // Modifiers
 export const reset: Color


### PR DESCRIPTION
Hi, looks like the `createColors` parameter type can be optional rather than forcing to explicitly passing argument.

```ts
// current behaviour  
createColors(true) // ok
createColors(false) // ok
createColors(undefined) // ok
createColors() // error

// proposed behaviour
createColors(true) // ok
createColors(false) // ok
createColors(undefined) // ok
createColors() // ok
```

If this behaviour is not wanted feel free to close the PR