### PR TITLE
Specify copyright holder properly.

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,37 @@
+Short version for non-laywers:
+  The Nano Colors project is licensed under MIT terms.
+
+Longer version:
+  Copyright 2021 Andrey Sitnik <andrey@sitnik.ru>
+
+  The Nano Colors project is licensed under the MIT license
+  <LICENSE> or <http://opensource.org/licenses/MIT>. Source
+  code if this project may not be copied, modified, or distributed
+  except according to those terms.
+
+
+The Nano Colors project includes codes derived from a third party.
+The following third party was used, and carry their own copyright
+notices and license terms:
+
+* colorette. Nano Colors is fork of colorette.
+
+    Copyright © Jorge Bucaran <<https://jorgebucaran.com>>
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the 'Software'), to
+    deal in the Software without restriction, including without limitation the
+    rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+    sell copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+    IN THE SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,6 @@
 The MIT License (MIT)
 
-Copyright 2021 Jorge Bucaran <mail@jorgebucaran.com>,
-Andrey Sitnik <andrey@sitnik.ru>
+Copyright 2021 Andrey Sitnik <andrey@sitnik.ru>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
1.  In the author section of "LICENSE" file, only copyright holders should be listed. It is true that Bucaran is the author of the colorette repo, but it doesn't mean that Bucaran automatically become a copyright holder of all derived works.

2.  Since nanocolors is derived work of colorette which is licensed under MIT license, the colorette's LICENSE term should be included in nanocolors' source code. I know it's lengthy but this is the proper way to use MIT licensed source code. Look at this term:

    > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.

By the way I'm grateful to see that Bucaran didn't DMCA takedown your repo this time.