### PR TITLE
Add automation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ Test configuration: ThinkPad X1 Carbon Gen 9, Fedora 34, Node.js 16.8.
    + red(bold(text))
    ```
 
+Automation: above changes can be applied automatically using [this codemod](https://gist.github.com/gavrix/ff051941ad9a19c8ea3224f38c30bc9a):
+```
+npx jscodeshift <path-to-js-files> -t https://gist.githubusercontent.com/gavrix/ff051941ad9a19c8ea3224f38c30bc9a/raw/09d81e93f880ecbc8f52dcf7819816c81e2ba340/chalk_nanocolors_transform.js
+```
 
 ## API
 


### PR DESCRIPTION
It seems migration from chalk to nanocolors can be easily automated using jscodeshift. I made the simple transformer (I put in a gist [here](https://gist.github.com/gavrix/ff051941ad9a19c8ea3224f38c30bc9a) and added instructions of how apply it in the README 